### PR TITLE
The main part of hw3 has been done

### DIFF
--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -8,6 +8,13 @@ spec:
   containers:
   - image: androidraddik/nginx_static_app:1.2
     name: web
+    livenessProbe:
+      tcpSocket:
+        port: 8000
+    readinessProbe:
+      httpGet:
+        path: /index.html
+        port: 80
     volumeMounts:
     - name: app
       mountPath: /app

--- a/kubernetes-networks/coredns/coredns-svc.yaml
+++ b/kubernetes-networks/coredns/coredns-svc.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dns-service-tcp
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "dns"
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 172.18.255.201
+  ports:
+    - name: dnstcp
+      protocol: TCP
+      port: 53
+      targetPort: 53
+  selector:
+    k8s-app: kube-dns
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dns-service-udp
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "dns"
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 172.18.255.201
+  ports:
+    - name: dnsudp
+      protocol: UDP
+      port: 53
+      targetPort: 53
+  selector:
+    k8s-app: kube-dns

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: example
+  namespace: metallb-system
+spec:
+  addresses:
+  - 172.18.255.200-172.18.255.250
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: empty
+  namespace: metallb-system

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,22 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+    - name: https
+      port: 443
+      targetPort: https

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+      - image: androidraddik/nginx_static_app:1.2
+        name: web
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      initContainers:
+      - image: busybox:1.31
+        name: init-web
+        command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      volumes:
+      - name: app
+        emptyDir: {}

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+  - http:
+      paths:
+      - path: /web
+        pathType: Prefix
+        backend:
+          service:
+            name: web-svc
+            port:
+              number: 8000

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - port: 80
+    targetPort: 8000
+    protocol: TCP

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8000


### PR DESCRIPTION
# Выполнено ДЗ № 3

 - [x] Основное ДЗ
 - [x] Задание со * dns
 - [ ] Другие задания со *

## В процессе сделано:
 - Добавлены проверки liveness и readiness в исходный манифест пода с nginx
 - Создан манифест объекта развертывание для подов с nginx
 - Написан манифест для сервиса по типу ClusterIP (доступ изнутри кластера)
 - Включен режим IPVS для kube-proxy вместо iptables
 - Установлен балансировщик Metallb L2 для "bare metal" сервера
 - Создан соответствующий манифест metallb-config.yaml для раздачи заданного пула адресов и "раздачи" их сервисам по умолчанию, у которых тип LoadBalancer. Установка проводилась согласно рекомендациям с официально сайта ввиду того факта, что настройка через ConfigMap теперь считается устаревшей
 - Создан сервис LoadBalancer для получения записей dns через внешний адрес
 - Установлен и запущен nginx ingress для получения доступа ко всем сервисам через единую точку L7

## Как запустить проект:
 - kubectl apply -f <manifest name>.yaml

## Как проверить работоспособность:
 - Перейти по ссылке 172.18.255.200:80 (Metallb без Ingress nginx)
![Снимок экрана от 2023-07-16 20-20-03](https://github.com/otus-kuber-2023-06/androidraddik_platform/assets/133522328/bfea9874-b1a4-453f-836f-be9cec9a321b)
 - Перейти по ссылке 172.18.255.202/web/index.html (Metallb с Ingress nginx)
 ![Снимок экрана от 2023-07-17 11-51-41](https://github.com/otus-kuber-2023-06/androidraddik_platform/assets/133522328/8523427b-7aa2-41f2-88aa-39efdb103cd3)

## PR checklist:
 - [x] Выставлен label с темой домашнего задания